### PR TITLE
Fix syntax errors and outdated imports

### DIFF
--- a/final_mnist.py
+++ b/final_mnist.py
@@ -158,30 +158,26 @@ plt.legend(['train', 'test'], loc='upper left')
 plt.show()
 
 
-
-
-fun(1,1)
-
 from mpl_toolkits import mplot3d
-%matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
 import math
 
-def fun(x,y):
-    a=cnf_matrix[math.floor(x),math.floor(y)]
-    return a;
+
+def fun(x, y):
+    """Lookup the value of the confusion matrix at (x, y)."""
+    return cnf_matrix[math.floor(x), math.floor(y)]
+
 
 def f(x, y):
     return np.sin(np.sqrt(x ** 2 + y ** 2))
+
 
 x = np.linspace(0, 9, 50)
 y = np.linspace(0, 9, 50)
 
 X, Y = np.meshgrid(x, y)
-for i in range(50):
-    Z[i]=fun(x[i],y[i])
-Z = f(X, Y)
+Z = np.vectorize(fun)(X, Y)
 fig = plt.figure()
 ax = plt.axes(projection='3d')
 ax.contour3D(X, Y, Z, 50, cmap='binary')

--- a/kfold.py
+++ b/kfold.py
@@ -47,14 +47,14 @@ print(model.summary())
 print('----------------------------------------------------------------------')
 
 SEED=42
-from sklearn import (metrics, cross_validation)
+from sklearn import metrics
 mean_auc = 0.0
 n = 10  # repeat the CV procedure 10 times to get more precise results
 for i in range(n):
     # for each iteration, randomly hold out 20% of the data as CV set
-    X_train, X_cv, y_train, y_cv = cross_validation.train_test_split(
-    X_t, y_t, test_size=0.2, random_state=i*SEED)
-    y_plt=y_cv
+    X_train, X_cv, y_train, y_cv = train_test_split(
+        X_t, y_t, test_size=0.2, random_state=i * SEED)
+    y_plt = y_cv
     
     # normalize inputs from 0-255 to 0-1
     X_train = X_train / 255
@@ -219,10 +219,9 @@ for i in range(10):
  
 vals_error = [0]*10
 for i in range(10):
-    vals_error[i]=100-vals_accuracy[i]
+    vals_error[i]=100 - vals_accuracy[i]
 
 
-%matplotlib inline
 plt.style.use('ggplot')
 
 x_pos = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']


### PR DESCRIPTION
## Summary
- remove stray IPython magic and debug call in final_mnist and implement proper 3‑D confusion matrix plotting
- replace deprecated sklearn.cross_validation usage with train_test_split
- drop unused IPython magic in kfold and cleanup plotting section

## Testing
- `python -m py_compile final_mnist.py kfold.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999167595c8322b46f58061202b8fb